### PR TITLE
Add Arize Phoenix support

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -46,6 +46,7 @@ Required API keys:
 - `GEMINI_API_KEY`
 - `GOOGLE_SEARCH_API_KEY`
 - `GOOGLE_CSE_ID`
+- `ENABLE_PHOENIX` (optional, enables Arize Phoenix tracing)
 
 ### 3. Start Data Layer
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The project is divided into two main directories:
   - `GEMINI_API_KEY`: Gemini 1.5 Pro (Synthesis & Reporting)
   - `GOOGLE_SEARCH_API_KEY` & `GOOGLE_CSE_ID`: Web search capabilities
   - `LANGSMITH_API_KEY`: Optional monitoring
+  - `ENABLE_PHOENIX`: Set to `true` to enable Arize Phoenix tracing
 
 ### Quick Setup
 

--- a/backend/env.example
+++ b/backend/env.example
@@ -49,4 +49,5 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # Monitoring (Optional)
 SENTRY_DSN=your_sentry_dsn_here
-DATADOG_API_KEY=your_datadog_api_key_here 
+DATADOG_API_KEY=your_datadog_api_key_here
+ENABLE_PHOENIX=false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "google-generativeai>=0.3.0",
     "anthropic>=0.25.0",
     "openai>=1.0.0",
+    "arize-phoenix>=3.16.0",
 ]
 
 

--- a/backend/src/agent/osint_graph_integrated.py
+++ b/backend/src/agent/osint_graph_integrated.py
@@ -27,6 +27,7 @@ from src.agent.osint_prompts import AGENT_PROMPTS
 from src.database.osint_database import get_database, OSINTDatabase
 from src.agent.osint_memory import OSINTMemoryManager, OSINTConversationMemory
 from src.agent.osint_tools import osint_retrieval_manager, OSINTSource, SourceType
+from src.agent.phoenix_integration import initialize_phoenix
 from src.agent.osint_agents_structured import (
     structured_agents, query_analysis_structured, planning_structured,
     pivot_analysis_structured, synthesis_structured, judge_structured
@@ -51,6 +52,8 @@ class IntegratedOSINTGraph:
         
     async def initialize(self, query: str, user_id: str = "system"):
         """Initialize the graph with database connections"""
+        # Enable Phoenix tracing if configured
+        initialize_phoenix()
         # Get database instance
         self.db = await get_database()
         

--- a/backend/src/agent/phoenix_integration.py
+++ b/backend/src/agent/phoenix_integration.py
@@ -1,0 +1,42 @@
+"""Arize Phoenix integration utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from phoenix.trace import OpenInferenceTracer
+    from phoenix.trace.langchain import LangChainInstrumentor
+except Exception:  # pragma: no cover - optional dependency
+    OpenInferenceTracer = None  # type: ignore
+    LangChainInstrumentor = None
+
+_tracer: Optional[OpenInferenceTracer] = None
+
+
+def initialize_phoenix() -> Optional[OpenInferenceTracer]:
+    """Initialize Arize Phoenix tracing if enabled via environment variable."""
+    enable = os.getenv("ENABLE_PHOENIX", "false").lower() in {"1", "true", "yes"}
+    if not enable:
+        logger.debug("Phoenix tracing not enabled")
+        return None
+
+    if OpenInferenceTracer is None or LangChainInstrumentor is None:
+        logger.warning("Arize Phoenix is not installed; tracing disabled")
+        return None
+
+    global _tracer
+    if _tracer is None:
+        _tracer = OpenInferenceTracer()
+        LangChainInstrumentor().instrument(tracer=_tracer)
+        logger.info("Arize Phoenix tracing enabled")
+    return _tracer
+
+
+def get_tracer() -> Optional[OpenInferenceTracer]:
+    """Return the global Phoenix tracer if initialized."""
+    return _tracer

--- a/backend/src/evaluation/phoenix_eval.py
+++ b/backend/src/evaluation/phoenix_eval.py
@@ -1,0 +1,30 @@
+"""Run agent evaluations with Arize Phoenix."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Any, Dict, Callable
+
+logger = logging.getLogger(__name__)
+
+try:
+    from phoenix.evals import run_evaluation  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    run_evaluation = None  # type: ignore
+
+
+def evaluate_dataset(dataset: Iterable[Dict[str, Any]], agent: Callable[[Dict[str, Any]], Dict[str, Any]]) -> Dict[str, Any]:
+    """Run an evaluation dataset through the agent using Phoenix.
+
+    Parameters
+    ----------
+    dataset: Iterable of data rows to evaluate.
+    agent: Callable that processes a single data row and returns a result.
+    """
+    if run_evaluation is None:
+        raise RuntimeError(
+            "arize-phoenix is not installed. Install it to run evaluations."
+        )
+
+    logger.info("Running evaluation with Arize Phoenix on %d items", len(list(dataset)))
+    return run_evaluation(dataset=dataset, agent=agent)


### PR DESCRIPTION
## Summary
- integrate optional tracing with Arize Phoenix
- expose evaluation helper for Phoenix datasets
- document new ENABLE_PHOENIX env variable

## Testing
- `python run_tests.py all` *(fails: missing packages due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef0be51083299a56c280718d7444